### PR TITLE
Replace NonDiscardingBinaryCodec with BinaryCodec

### DIFF
--- a/src/X509/RequestSigner.php
+++ b/src/X509/RequestSigner.php
@@ -8,6 +8,7 @@ use Bip70\Protobuf\Codec\NonDiscardingBinaryCodec;
 use Bip70\Protobuf\Proto\PaymentDetails;
 use Bip70\Protobuf\Proto\PaymentRequest;
 use Bip70\Protobuf\Proto\X509Certificates;
+use DrSlump\Protobuf\Codec\Binary as BinaryCodec;
 use Sop\CryptoBridge\Crypto;
 use Sop\CryptoTypes\AlgorithmIdentifier\Feature\AsymmetricCryptoAlgorithmIdentifier;
 use Sop\CryptoTypes\Asymmetric\PrivateKeyInfo;
@@ -61,7 +62,7 @@ class RequestSigner implements RequestSignerInterface
         $request->setSerializedPaymentDetails($details->serialize());
         $request->setSignature('');
 
-        $data = $request->serialize(new NonDiscardingBinaryCodec());
+        $data = $request->serialize(new BinaryCodec());
         $signature = $this->crypto->sign($data, $privateKey, $signAlgorithm);
 
         $request->setSignature($signature->bitString()->string());


### PR DESCRIPTION
The custom NonDiscardingBinaryCodec appears to cause problems with the Electrum/Electron clients.

It looks like Electrum may discard empty fields when it receives the payload. Discarding these prior to sending the payload may be a better option to increase compatibility with Wallet Clients - as, if these are empty, they should not be necessary anyway.

This was the cause for the problem encountered in Issue:

#15 